### PR TITLE
fix jsdoc rules

### DIFF
--- a/configs/ts.json
+++ b/configs/ts.json
@@ -128,7 +128,19 @@
           "error"
         ],
         "semi": "off",
-        "@typescript-eslint/semi": "error"
+        "@typescript-eslint/semi": "error",
+        "jsdoc/check-param-names": [
+          "warn",
+          {
+            "checkDestructured": false
+          }
+        ],
+        "jsdoc/require-param": [
+          "warn",
+          {
+            "checkDestructured": false
+          }
+        ]
       }
     }
   ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-codex",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "main": "index.js",
   "repository": "github:codex-team/eslint-config",
   "license": "MIT",


### PR DESCRIPTION
сейчас линтер хочет, чтобы при деструктуризации в параметрах функции мы отдельно описывали каждое поле
в TypeScript это правило практически неактуально, потому что документацию к полям можно найти и в интерфейсе + документация получается слишком избыточной и с большим количеством повторений
![image](https://user-images.githubusercontent.com/32655339/101202933-05bbc080-367b-11eb-9ba3-7897af7a1503.png)
