### PR TITLE
feat(jsdoc): enforce empty line before jsdoc tags

### DIFF
--- a/common.json
+++ b/common.json
@@ -199,7 +199,8 @@
     "dot-notation": 0,
     "no-empty": 0,
     "object-curly-spacing": ["warn", "always"],
-    "keyword-spacing": ["warn"]
+    "keyword-spacing": ["warn"],
+    "jsdoc/tag-lines": ["warn", "any", {"startLines": 1}]
   },
   "globals":{
     "document": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-codex",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "main": "index.js",
   "repository": "github:codex-team/eslint-config",
   "license": "MIT",

--- a/test/index.ts
+++ b/test/index.ts
@@ -18,6 +18,7 @@ class User {
 
   /**
    * Public method should be placed abode the private and below the constructor
+   * @param adad - ads
    */
   public hello(): void {
     console.log('hello');


### PR DESCRIPTION
Enforce empty line before jsdoc tags

<img width="738" alt="image" src="https://github.com/codex-team/eslint-config/assets/3684889/3831137a-ec79-4949-a521-bf11399c06b5">
