### PR TITLE
Patched add ignore patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-codex",
-  "version": "1.8.4",
+  "version": "1.9.2",
   "main": "index.js",
   "repository": "github:codex-team/eslint-config",
   "license": "MIT",

--- a/ts.json
+++ b/ts.json
@@ -17,6 +17,7 @@
       },
       "parser": "@typescript-eslint/parser",
       "rules": {
+        "no-unused-vars": "off",
         "@typescript-eslint/no-unused-vars": ["error", {
           "args": "after-used",
           "argsIgnorePattern": "^_",


### PR DESCRIPTION
## Problem 
"no-unused-vars" rule still reports about unused vars (ignore patterns are not respected)
![image](https://github.com/codex-team/eslint-config/assets/130844513/0882ffaf-d656-4813-8632-63ef407b42fe)
## Cause
Base rule "no-unused-vars" (without ignored patterns added in) [this commit](https://github.com/codex-team/eslint-config/commit/0e4f5a96389918395ac33e0a12994a5c360d96d8))
check [this documentation](https://typescript-eslint.io/rules/no-unused-vars/#how-to-use) for details
## Solution
Disable the base rule as it can report incorrect errors (use "@typescript-eslint/no-unused-vars" with ignore patterns)