### PR TITLE
fix(ci): use node 20 on ci

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           registry-url: https://registry.npmjs.org/
       - run: yarn
       - run: yarn publish --access=public

--- a/index.js
+++ b/index.js
@@ -1,3 +1,2 @@
 import CodeX from './eslint.config.mjs';
-
 export default CodeX;


### PR DESCRIPTION
This PR fixes failed job: 

https://github.com/codex-team/eslint-config/actions/runs/8765322765/job/24056213307#step:4:14


```
yarn install v1.22.22
[1/4] Resolving packages...
[2/4] Fetching packages...
error @eslint/js@9.1.1: The engine "node" is incompatible with this module. Expected version "^18.18.0 || ^20.9.0 || >=21.1.0". Got "16.20.2"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Error: Process completed with exit code 1.
```