### PR TITLE
chore[rules]: added filters for property selector of the naming-convention

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-codex",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "index.js",
   "repository": "github:codex-team/eslint-config",
   "license": "MIT",

--- a/src/configs/typescript.mjs
+++ b/src/configs/typescript.mjs
@@ -151,6 +151,9 @@ export default [
           'PascalCase',
         ],
       },
+      /**
+       * Use camelCase for property names that dont satisfy regex
+       */
       {
         selector: 'property',
         format: ['camelCase'],
@@ -159,6 +162,9 @@ export default [
           match: true,
         },
       },
+      /**
+       * Property names that satisfy regex are used without any format rules
+       */
       {
         selector: 'property',
         format: null,

--- a/src/configs/typescript.mjs
+++ b/src/configs/typescript.mjs
@@ -163,7 +163,7 @@ export default [
         },
       },
       /**
-       * Property names that satisfy regex are used without any format rules
+       *  Allows "2xx" (and similar) as a property name, used in the API response schema
        */
       {
         selector: 'property',

--- a/src/configs/typescript.mjs
+++ b/src/configs/typescript.mjs
@@ -150,7 +150,24 @@ export default [
         format: [
           'PascalCase',
         ],
-      }],
+      },
+      {
+        selector: 'property',
+        format: ['camelCase'],
+        filter: {
+          regex: '^(?!(2xx|2[0-9][0-9]|application/json)$).*',
+          match: true,
+        },
+      },
+      {
+        selector: 'property',
+        format: null,
+        filter: {
+          regex: '^(2xx|2[0-9][0-9]|application/json)$',
+          match: true,
+        },
+      },
+      ],
       'no-shadow': 'off',
       '@typescript-eslint/no-shadow': 'error',
       '@typescript-eslint/consistent-type-imports': 'error',

--- a/test/rules/typescript/naming-convention.ts
+++ b/test/rules/typescript/naming-convention.ts
@@ -1,0 +1,6 @@
+const response = {
+  '2xx': 'value',
+  205: 'value',
+  305: 'value',
+  'application/json': 'value',
+};


### PR DESCRIPTION
## Problem
![image](https://github.com/codex-team/eslint-config/assets/130844513/f539ac06-af60-4e30-a38f-2b118d4501a7)
We cannot use property names like 2xx, 2[0-9][0-9], application/json, because they should match one of the following cases: camelCase, PascalCase, UPPER_CASE

## Solution
added filters for property selecrots in naming convention
![image](https://github.com/codex-team/eslint-config/assets/130844513/b8ce3f2f-0239-49b4-bb7c-be784ee6cfd6)

